### PR TITLE
Update pipeline reference

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 include:
   - project: "wma/nhgf/nldi/mirror-pipelines"
-    ref: "2022-05-23-r1"
+    ref: "2022-08-24-r0"
     file:
       - "nldi-crawler.yml"


### PR DESCRIPTION
Updated the pipeline reference to a new tag. The nldi-cralwer pipeline file did not exist at the previous tag.