### PR TITLE
Fix temp table failure state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/internetofwater/nldi-crawler/compare/nldi-crawler-1.0.0...master)
+## [Unreleased](https://github.com/internetofwater/nldi-crawler/compare/1.1.1...master)
+### Fixed
+- Subsequent executions after a failed run now properly re-initialize the temp table
+
+## [1.1.1](https://github.com/internetofwater/nldi-crawler/compare/nldi-crawler-1.1.0...1.1.1)
 ### Added
 - Support for generic GeoJSON geometry types within a feature
 

--- a/src/main/java/gov/usgs/owi/nldi/dao/IngestDao.java
+++ b/src/main/java/gov/usgs/owi/nldi/dao/IngestDao.java
@@ -43,6 +43,5 @@ public class IngestDao extends BaseDao {
   @Transactional
   public void initTempTable(@NonNull String tempTableName) {
     getSqlSession().insert(NS + "createTempTable", tempTableName);
-    getSqlSession().delete(NS + "truncateTempTable", tempTableName);
   }
 }

--- a/src/main/resources/mybatis/mappers/ingest.xml
+++ b/src/main/resources/mybatis/mappers/ingest.xml
@@ -25,13 +25,10 @@
 	</update>
 
 	<insert id="createTempTable">
+		drop table if exists nldi_data.${tempTableName,jdbcType=VARCHAR};
 		create table if not exists nldi_data.${tempTableName,jdbcType=VARCHAR}
-			(like nldi_data.feature)
+			(like nldi_data.feature);
 	</insert>
-
-	<delete id="truncateTempTable">
-		truncate table nldi_data.${tempTableName,jdbcType=VARCHAR}
-	</delete>
 
 	<update id="install">
 		set search_path = nldi_data;


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make pull request title clear and descriptive
- [ ] Link(s) to issue describing bug fixed or need for change
- [x] Make sure all tests run
- [x] Update the changelog appropriately

Description
---------------------------
The database can get into a failure state that causes the crawler to be unable to recover. In this instance, the crawler created a temporary table that was built from a table missing the `shape` column. After its failure, Liquibase was run to update the tables to have that column. The crawler was run a second time and did not recreate the temporary table because it already existed. This causes it to always fail because it cannot find the shape column. These changes ensure that the crawler drops the temporary table and recreates it.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
